### PR TITLE
Adding call back later feature

### DIFF
--- a/extract/date_info_Google.py
+++ b/extract/date_info_Google.py
@@ -116,10 +116,13 @@ def extract_date_time(s):
     """ If extract_date_time_base doesn't succeed, try again having replaced
     homonyms.
     """
+#    return (extract_date_time_base(s) or
+#            extract_date_time_base(replace_homonyms(s), words_to_nums=True) or
+#            {'year': None, 'month': None, 'day': None,
+#             'hour': None, 'minute': None})
     return (extract_date_time_base(s) or
             extract_date_time_base(replace_homonyms(s), words_to_nums=True) or
-            {'year': None, 'month': None, 'day': None,
-             'hour': None, 'minute': None})
+            None)
     
 
 if __name__ == "__main__":

--- a/extract/location_info_Google.py
+++ b/extract/location_info_Google.py
@@ -29,11 +29,11 @@ def extract_location(s):
                 'Zipcode': possible_locations[0][1], 
                 'Confidence_location': "low"}
     else:
-        return {'State': None,
-                'City': None,
-                'Zipcode': None, 
-                'Confidence_location': None}    
- 
+#        return {'State': None,
+#                'City': None,
+#                'Zipcode': None, 
+#                'Confidence_location': None}    
+        return None
 
 if __name__ == "__main__":
     ss = [

--- a/runners.py
+++ b/runners.py
@@ -185,9 +185,24 @@ If you call with no arguments, all runners will start."""
     parser.add_argument('--re_transcribe', 
                         help='Include previously transcribed records in entity transcription, used for testing', 
                         action='store_true')
+    parser.add_argument('--tryAgain', 
+                        help='Try calling again numbers for which we failed to get location date info', 
+                        action='store_true')
+    parser.add_argument('--setCallingToNew', 
+                        help='Resets statuses stuck on calling to new', 
+                        action='store_true')
 
 
     args = vars(parser.parse_args())
+
+    if args.pop('tryAgain'):
+        db = Database()
+        db.change_status(Statuses.failed_to_return_info, Statuses.new)
+
+    if args.pop('setCallingToNew'):
+        db = Database()
+        db.change_status(Statuses.calling, Statuses.new)
+
 
     if args.pop('re_extract'):
         db = Database()

--- a/storage/databases/azure_table.py
+++ b/storage/databases/azure_table.py
@@ -119,9 +119,12 @@ class AzureTableDatabase(object):
 
     def update_location_date(self, partition_key, location_dict, date_dict):
         record = self.connection.get_entity(self.table_name, partition_key, partition_key)
-        record.update(**location_dict)
-        record.update(**date_dict)
-        record.Status = Statuses.extracting_done
+        if location_dict and date_dict:
+            record.update(**location_dict)
+            record.update(**date_dict)
+            record.Status = Statuses.extracting_done
+        else:
+            record.Status = Statuses.failed_to_return_info
         self._update_entity(record)
 
     def upload_new_requests(self, request_ids):

--- a/storage/filestorage.py
+++ b/storage/filestorage.py
@@ -2,6 +2,7 @@
 handle downloading and reuploading files to our own servers
 """
 
+import os
 import requests
 import uuid 
 from utils.tempfilemanager import TmpFileCleanup
@@ -22,7 +23,8 @@ class BlobManager(object):
         azure_path = "/recordings/" + short_file_name
 
         with TmpFileCleanup() as tmp_file_store:
-            local_filename = local_tmp_dir + "/" + short_file_name
+#            local_filename = local_tmp_dir + "/" + short_file_name
+            local_filename = os.path.join(local_tmp_dir, short_file_name)
             tmp_file_store.tmp_files.append(local_filename)
             f = open(local_filename, "wb")
             f.write(response.content)

--- a/storage/models.py
+++ b/storage/models.py
@@ -18,7 +18,7 @@ class Statuses(object):
     extracting = "extracting_info"
     extracting_done = "extracting_done"
     error = "error"
-
+    failed_to_return_info = "failed_to_return_info"
 
 Statuses.reset_map = {
     Statuses.calling: Statuses.new,


### PR DESCRIPTION
Sets a new error status when program unable to extract any information from the transcript.  You can then run the program again for all cases with that error status with the --tryAgain option
also, ensures that paths for twilio download locations are compatible across different os's.