### PR TITLE
Add failure counter to runners

### DIFF
--- a/call/place_call.py
+++ b/call/place_call.py
@@ -43,7 +43,7 @@ class TwilioCallWrapper(object):
         Wait for 10 seconds
         Send 1  [trick into a repeat so we catch the full message.]
         """
-        return "1ww{case_number}ww1ww1ww1".format(case_number=case_number) + ("w" * 5 * 2) + "1" 
+        return "1ww{case_number}ww1ww1ww1".format(case_number=case_number) + ("w" * 5 * 2) + "1"
         #return "1w1ww{case_number}ww1w1w1".format(case_number=case_number) + ("w" * 5 * 2) + "1" #If warning of maintenance
 
 
@@ -65,7 +65,7 @@ class TwilioCallWrapper(object):
         # get a fresh call.
         recordings = call.recordings.list()
         if not recordings:
-            raise TemporaryChillError(60 * 5)
+            raise TemporaryChillError(10) # remove (60 * 5)
         recording = recordings[0]
         recording_uri = recording.uri
 

--- a/call/place_call.py
+++ b/call/place_call.py
@@ -65,7 +65,7 @@ class TwilioCallWrapper(object):
         # get a fresh call.
         recordings = call.recordings.list()
         if not recordings:
-            raise TemporaryChillError(10) # remove (60 * 5)
+            raise TemporaryChillError(60 * 5)
         recording = recordings[0]
         recording_uri = recording.uri
 

--- a/call/place_call.py
+++ b/call/place_call.py
@@ -43,7 +43,9 @@ class TwilioCallWrapper(object):
         Wait for 10 seconds
         Send 1  [trick into a repeat so we catch the full message.]
         """
-        return "1ww{case_number}ww1ww1ww1".format(case_number=case_number) + ("w" * 5 * 2) + "1"
+        return "1ww{case_number}ww1ww1ww1".format(case_number=case_number) + ("w" * 5 * 2) + "1" 
+        #return "1w1ww{case_number}ww1w1w1".format(case_number=case_number) + ("w" * 5 * 2) + "1" #If warning of maintenance
+
 
     def place_call(self, case_number):
         send_digits = self.build_dtmf_sequence(case_number)

--- a/extract/date_info_Google.py
+++ b/extract/date_info_Google.py
@@ -35,7 +35,7 @@ def create_digits_for_date_parsing(s):
 
 
 def get_re_for_date_parsing():
-    """ 
+    """
     Basically matches strings beginning with a month, and ending in AM or PM
     In between the month and AM/PM, matching is non-greedy.
     Uses lookahead with grouping to find overlapping matches.
@@ -53,7 +53,7 @@ def get_re_for_date_parsing():
 
 def find_possible_date_times(s, words_to_nums):
     """ Example:
-    s = 'blah blah thirty one may st new york new york on april third, 
+    s = 'blah blah thirty one may st new york new york on april third,
          two thousand seventeen at one thirty PM blah blah'
     returns
     list('april 3rd, 2017 at 1:30 p.m.',
@@ -73,7 +73,7 @@ def find_possible_date_times(s, words_to_nums):
 
 def extract_date_time_base(s, words_to_nums=False):
     """ Example:
-    s = 'blah blah thirty one may st new york new york on april third, 
+    s = 'blah blah thirty one may st new york new york on april third,
          two thousand seventeen at one thirty PM blah blah'
     returns
     dict('year': 2017,
@@ -81,11 +81,11 @@ def extract_date_time_base(s, words_to_nums=False):
          'day': 3,
          'hour': 13,
          'minute': 30)
-    
+
     minute default to 0 if none found.
     All other keys default to None.
 
-    Loops through possible dates, returns as soon as dparser succeeds in 
+    Loops through possible dates, returns as soon as dparser succeeds in
     parsing date.
     """
     possible_dates = find_possible_date_times(s, words_to_nums)
@@ -103,7 +103,7 @@ def extract_date_time_base(s, words_to_nums=False):
             for key in d:
                 if dt_1.__getattribute__(key) == dt_2.__getattribute__(key):
                     d[key] = dt_1.__getattribute__(key)
-            
+
             d["minute"] = dt_1.minute
 
             return d
@@ -123,7 +123,7 @@ def extract_date_time(s):
     return (extract_date_time_base(s) or
             extract_date_time_base(replace_homonyms(s), words_to_nums=True) or
             None)
-    
+
 
 if __name__ == "__main__":
     ss = [

--- a/extract/location_info_Google.py
+++ b/extract/location_info_Google.py
@@ -26,13 +26,13 @@ def extract_location(s):
     if possible_locations != []:
         return {'State': possible_locations[0][0],
                 'City': None,
-                'Zipcode': possible_locations[0][1], 
+                'Zipcode': possible_locations[0][1],
                 'Confidence_location': "low"}
     else:
 #        return {'State': None,
 #                'City': None,
-#                'Zipcode': None, 
-#                'Confidence_location': None}    
+#                'Zipcode': None,
+#                'Confidence_location': None}
         return None
 
 if __name__ == "__main__":
@@ -44,4 +44,3 @@ if __name__ == "__main__":
     for s in ss:
         print('\n' + s)
         print(extract_location(s))
-    

--- a/runners.py
+++ b/runners.py
@@ -1,5 +1,6 @@
 import threading
 import uuid
+import sys
 
 from datetime import datetime, timedelta
 from raven import Client
@@ -9,24 +10,29 @@ from call.place_call import TwilioCallWrapper
 from storage.filestorage import BlobManager
 from storage.models import Database, NoRecordsToProcessError, Statuses
 from storage.secrets import local_tmp_dir, sentry_dsn
-from transcribe.transcribe import BingTranscriber, GoogleTranscriber
-from utils.exceptions import TemporaryChillError
+from transcribe.transcribe import GoogleTranscriber, TranscriptionStatus
+from utils.exceptions import (TemporaryChillError, 
+    TooManyErrorsException, TranscriptionError, TwilioResponseError)
 from utils.tempfilemanager import TmpFileCleanup
 from extract.date_info_Google import extract_date_time
 from extract.location_info_Google import extract_location
 
 
+
 class RunnerBase(object):
 
+    # Max number of consecutive errors allowed in a runner before shutting down
+    # program
+    MAX_ALLOWABLE_ERRORS = 30
     default_sleep_time = 5  # seconds
 
-
 class CourtCallRunner(RunnerBase):
-
-    def __init__(self):
+    def __init__(self, stop_event):
         self._database = Database()
-        self._caller = TwilioCallWrapper(self._call_placed_callback, self._call_done_callback)
+        self._caller = TwilioCallWrapper(self._call_placed_callback, 
+            self._call_done_callback)
         self._caller.try_server()
+        self.consec_error_count = 0
 
     def __str__(self):
         return "CourtCallRunner"
@@ -39,15 +45,19 @@ class CourtCallRunner(RunnerBase):
         next stages are to call speech to text api then
         semantic extraction
         """
+        if self.consec_error_count > self.MAX_ALLOWABLE_ERRORS:
+            raise TooManyErrorsException
         next_ain = self._database.retrieve_next_record_for_call()
         print("Processing {0}".format(next_ain))
         try:
             self._caller.place_call(next_ain)
+            self.consec_error_count = 0
         except:
             # reset and throw
             print("Rolling back {0}".format(next_ain))
             self._database.set_error(next_ain, Statuses.new)
-            raise
+            self.consec_error_count += 1
+            raise 
 
     def _call_placed_callback(self, ain, call_id):
         """ Update database to say that a call was started and set call id """
@@ -58,29 +68,33 @@ class CourtCallRunner(RunnerBase):
         """
         Download the call and reupload to azure.
 
-        Update database to say that a call was started and save the recording location.
+        Update database to say that a call was started 
+        and save the recording location.
         """
         print("Call duration was: {0}".format(call_duration))
         try:
             azure_path = BlobManager().download_and_reupload(recording_uri)
             print("Azure path: ", azure_path)
-            self._database.update_azure_path(ain, azure_path)
-        except ValueError as e:
-            print("Error!: {0}".format(e))
+            self._database.update_azure_path(ain, azure_path)            
+        except TwilioResponseError as e:
+            raise
 
 
 class TranscribeRunner(RunnerBase):
 
-    def __init__(self):
+    def __init__(self, stop_event):
         self.blob_manager = BlobManager()
-        # self.bingTranscriber = BingTranscriber()
         self.googleTranscriber = GoogleTranscriber()
         self.azure_table = Database()
+        self.consec_error_count = 0
 
     def __str__(self):
         return "TranscribeRunner"
 
     def call(self):
+        if self.consec_error_count > self.MAX_ALLOWABLE_ERRORS:
+            raise TooManyErrorsException
+
         azure_blob, partition_key = \
             self.azure_table.retrieve_next_record_for_transcribing()
 
@@ -96,25 +110,38 @@ class TranscribeRunner(RunnerBase):
                 self.googleTranscriber.transcribe_audio_file_path(
                     local_filename,
             )
-            self.azure_table.update_transcript(partition_key, transcript, status)
-
+            self.azure_table.update_transcript(partition_key, 
+                transcript, status)
+        if status != TranscriptionStatus.success:
+            self.consec_error_count += 1
+            raise TranscriptionError("Transcription failed, status: " + status)
+        else:
+            self.consec_error_count = 0
 
 class EntityRunner(RunnerBase):
 
-    def __init__(self):
+    def __init__(self, stop_event):
         self.azure_table = Database()
+        self.consec_error_count = 0
 
     def __str__(self):
         return "EntityRunner"
 
     def call(self):
+        if self.consec_error_count > self.MAX_ALLOWABLE_ERRORS:
+            raise TooManyErrorsException
+
         transcript, partition_key = self.azure_table.retrieve_next_record_for_extraction()
         location_dict = extract_location(transcript)
         print("Location: " + str(location_dict))
         date_dict = extract_date_time(transcript)
         print("Date, time: " + str(date_dict))
-        self.azure_table.update_location_date(partition_key, location_dict, date_dict)
-
+        self.azure_table.update_location_date(partition_key, 
+            location_dict, date_dict)
+        if location_dict == None or date_dict == None:
+            self.consec_error_count += 1
+        else:
+            self.consec_error_count = 0
 
 class ErrorRecovery(RunnerBase):
     """
@@ -123,9 +150,9 @@ class ErrorRecovery(RunnerBase):
         - Error states.
     """
 
-    default_sleep_time = 60 * 10  # ten minutes
+    default_sleep_time = 60 * 10 
 
-    def __init__(self):
+    def __init__(self, stop_event):
         self.azure_table = Database()
 
     def __str__(self):
@@ -142,29 +169,43 @@ class ErrorRecovery(RunnerBase):
 
 class RunnerThread(threading.Thread):
 
-    def __init__(self, runnerClass):
+    def __init__(self, runnerClass, stop_event):
         threading.Thread.__init__(self)
-        self.runner = runnerClass()
+        self.runner = runnerClass(stop_event)
         self.client = Client(sentry_dsn)
-
+        self.stop_event = stop_event
+        
     def __str__(self):
         return str(self.runner)
 
-    def run(self):
-        while 1:
+    def run(self): 
+        while not self.stop_event.isSet():
             try:
                 self.runner.call()
                 print("{0}: Sleeping after success".format(self.runner))
                 sleep(self.runner.default_sleep_time)
             except NoRecordsToProcessError:
                 print("{0}: Nothing to do: sleeping for five minutes".format(self.runner))
-                sleep(60 * 5)
+                sleep(60*5)  
             except TemporaryChillError as e:
                 print("{0}: Temporary chill for {1} seconds".format(self.runner, e.pause_time))
                 self.client.captureException()
                 sleep(e.pause_time)
             except KeyboardInterrupt:
+                sys.exit("Exited due to Keyboard Interrupt")
                 return
+            except TooManyErrorsException:
+                print("\n Too many consecutive errors with the " + 
+                      str(self.runner) + " thread; Setting stop event \n")
+                self.stop_event.set()
+                return
+            except TranscriptionError as e:
+                print("{0}: {1}".format(self.runner,e))
+            except TwilioResponseError as e:
+                print("{0}: {1}".format(self.runner,e))
+
+
+        print("The " + str(self.runner) + " thread has received a stop event")
 
 
 if __name__ == "__main__":
@@ -191,6 +232,9 @@ If you call with no arguments, all runners will start."""
     parser.add_argument('--setCallingToNew', 
                         help='Resets statuses stuck on calling to new', 
                         action='store_true')
+    parser.add_argument('--set_to_new',
+                        help='Resets all status to new, used for testing', 
+                        action='store_true')
 
 
     args = vars(parser.parse_args())
@@ -216,7 +260,18 @@ If you call with no arguments, all runners will start."""
         db.change_status(Statuses.extracting, Statuses.recording_ready)
         db.change_status(Statuses.extracting_done, Statuses.recording_ready)
 
-    
+    if args.pop('set_to_new'):
+        db = Database()
+        db.change_status(Statuses.transcribing_done, Statuses.new)
+        db.change_status(Statuses.transcribing, Statuses.new)
+        db.change_status(Statuses.extracting, Statuses.new)
+        db.change_status(Statuses.extracting_done, Statuses.new)
+        db.change_status(Statuses.calling, Statuses.new)
+        db.change_status(Statuses.failed_to_return_info, Statuses.new)
+        db.change_status(Statuses.error, Statuses.new)
+
+
+
     runnables = [k for k, v in args.items() if v]
     if not runnables:
         # if none passed, run them all.
@@ -227,18 +282,22 @@ If you call with no arguments, all runners will start."""
                     'recover': ErrorRecovery,
                     'parse': EntityRunner}
 
+    stop_event = threading.Event() #all threads will share this stop event
+
     for runnable in runnables:
-        thread = RunnerThread(runnable_map.get(runnable))
+        thread = RunnerThread(runnable_map.get(runnable), stop_event)
         thread.start()
 
     def interrupt(*args, **kwargs):
         sys.exit(0)
 
     signal.signal(signal.SIGINT, interrupt)
-    while 1:
-        sleep(60)
+
+    while not stop_event.isSet():
+        sleep(60)  
         print("There are {0} threads active:".format(threading.active_count()))
-        if not threading.active_count():
-            break
+
         for thread in threading.enumerate():
             print("{0}: {1}".format(thread.name, thread))
+
+        

--- a/storage/filestorage.py
+++ b/storage/filestorage.py
@@ -8,6 +8,7 @@ import uuid
 from utils.tempfilemanager import TmpFileCleanup
 from azure.storage.blob import BlockBlobService, ContentSettings
 from storage.secrets import blob_key, blob_accountname, blob_container, local_tmp_dir
+from utils.exceptions import TwilioResponseError
 
 class BlobManager(object):
 
@@ -16,7 +17,7 @@ class BlobManager(object):
         blob_service = BlockBlobService(account_name=blob_accountname, account_key=blob_key)
         response = requests.get(twilio_filename)
         if response.status_code != 200:
-            raise ValueError("Couldn't find Twilio file {0}".format(twilio_filename))
+            raise TwilioResponseError("Couldn't find Twilio file {0}".format(twilio_filename))
 
         suffix = "wav"
         short_file_name = "{0}.{1}".format(uuid.uuid4(), suffix)

--- a/transcribe/transcribe.py
+++ b/transcribe/transcribe.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-
+import sys
 import speech_recognition as sr
 from transcribe.secrets import (
     bing_speech_api_key,
@@ -68,5 +68,6 @@ class GoogleTranscriber(object):
                 print("Could not request results from Google Cloud Speech "
                       "service; {0}".format(e))
             except:
+                print("Unknown transcription error:", sys.exc_info())
                 error = TranscriptionStatus.unknown_error
         return transcript, error

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -11,3 +11,6 @@ class TranscriptionError(Exception):
 
 class TwilioResponseError(Exception):
 	pass
+
+class EntityExtractionError(Exception):
+    pass

--- a/utils/exceptions.py
+++ b/utils/exceptions.py
@@ -2,3 +2,12 @@ class TemporaryChillError(Exception):
 
     def __init__(self, numseconds):
         self.pause_time = numseconds
+
+class TooManyErrorsException(Exception):
+	pass
+
+class TranscriptionError(Exception):
+	pass
+
+class TwilioResponseError(Exception):
+	pass


### PR DESCRIPTION
If the calling, parsing, or transcribing threads reach a max number of consecutive errors, it sends a message to all other threads to stop calling the runners.  This is to avoid wasting money on calls or transcriptions if the number is undergoing maintenance, etc.  Tested on all runners by manually raising errors.

